### PR TITLE
Include node 0.12, iojs in the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
 node_js:
+  - "iojs"
+  - "0.12"
   - "0.11"
   - "0.10"


### PR DESCRIPTION
Excellent work on this library! I'l love to see builds for node 0.12 and the latest iojs as they have a pretty quick release cycle. Thanks!