### PR TITLE
Use Chai to perform diffs

### DIFF
--- a/lib/chai-subset.js
+++ b/lib/chai-subset.js
@@ -1,14 +1,20 @@
 var CircularJSON = require('circular-json');
 
-module.exports = function(chai) {
-	chai.Assertion.addChainableMethod('containSubset', function (expected) {
-		var actual = this.__flags.object;
-		var msg = "\n" + CircularJSON.stringify(actual, null, "\t") + "\n";
-		this.assert(
+module.exports = function(chai, utils) {
+	var Assertion = chai.Assertion;
+	var assertionPrototype = Assertion.prototype;
+
+	Assertion.addChainableMethod('containSubset', function (expected) {
+		var actual = utils.flag(this, 'object');
+		var showDiff = chai.config.showDiff;
+
+		assertionPrototype.assert.call(this,
 			compare(expected, actual),
-				'expected' + msg + 'to contain subset \n#{exp}',
-				'expected' + msg + 'not to contain subset \n#{exp}',
-			expected
+			'expected #{act} to contain subset #{exp}',
+			'expected #{act} to not contain subset #{exp}',
+			expected,
+			actual,
+			showDiff
 		);
 	});
 };


### PR DESCRIPTION
This chai-subset plugin has its own "comparison" implementation that is shown when an assertion does not match. In my test, the output looks like:

```
  11 passing (20ms)
  1 failing

  1) plain object should pass for smaller object:
     AssertionError: expected
{
	"a": "b",
	"c": "d"
}
to contain subset 
{ a: 'ba' }
```

Yes, the spacing is actually misaligned in the console, but that is not a big deal.

I think this can be improved by letting Chai handle the diff process like it does for its core assertions. Developers can set the Chai [config](http://chaijs.com/guide/styles/#configure) showDiff to either true or false, with true being the default.

Here is what Chai's built-in diff looks like:

```
  11 passing (16ms)
  1 failing

  1) plain object should pass for smaller object:

      AssertionError: expected { a: 'b', c: 'd' } to contain subset { a: 'ba' }
      + expected - actual

       {
      +  "a": "ba"
      -  "a": "b"
      -  "c": "d"
       }
``` 

When delegating the diff process to Chai, the spacing is correctly aligned and you get some neat green text where there should be additions (+) to the object and red text for the opposite case (-).

Please try it out with a failing test case and let me know what you think!